### PR TITLE
soft-delete 'setDeleted' feature

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-  "plugins": [ "add-module-exports" ],
-  "presets": [ "es2015" ]
+  "presets": [ "env" ],
+  "plugins": [
+    "add-module-exports",
+    "transform-runtime"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-hooks-common",
-  "version": "3.6.1",
+  "version": "3.7.3",
   "description": "Useful hooks for use with Feathersjs services.",
   "main": "lib/",
   "directories": {
@@ -54,7 +54,7 @@
   "homepage": "https://github.com/feathersjs/feathers-hooks-common#readme",
   "dependencies": {
     "ajv": "^5.2.0",
-    "debug": "^2.2.0",
+    "debug": "^3.0.0",
     "feathers-errors": "^2.4.0",
     "feathers-hooks": "^2.0.1",
     "traverse": "^0.6.6"
@@ -63,8 +63,9 @@
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-polyfill": "^6.20.0",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
     "chai": "^4.0.0",
     "coveralls": "^2.11.14",
     "eslint-if-supported": "^1.0.1",

--- a/src/services/soft-delete.js
+++ b/src/services/soft-delete.js
@@ -1,81 +1,128 @@
-
-import feathersErrors from 'feathers-errors';
+import { NotFound } from 'feathers-errors';
 import checkContext from './check-context';
 
-const errors = feathersErrors.errors;
+/******************************************************************************/
+// Data
+/******************************************************************************/
 
-export default function (field) {
-  const deleteField = field || 'deleted';
+const DEFAULTS = {
+  field: 'deleted',
+  setDeleted: () => true
+};
 
-  return function (hook) {
-    const service = hook.service;
-    hook.data = hook.data || {};
-    hook.params.query = hook.params.query || {};
+const SKIP = '$disableSoftDelete';
+
+const NOT_DELETED = { $in: [ false, null, undefined ] };
+
+/******************************************************************************/
+// Helpers
+/******************************************************************************/
+
+function validate (config) {
+  if (config && typeof config === 'string') { // no blank strings
+    config = { field: config };
+  }
+
+  if (!config || typeof config !== 'object') {
+    config = { };
+  }
+
+  const options = Object.assign({}, DEFAULTS, config);
+  if (typeof options.setDeleted !== 'function') {
+    throw new Error('config.setDeleted must be a function.');
+  }
+
+  return options;
+}
+
+async function throwIfDeleted (hook, { field }) {
+  const { service, id, method, app } = hook;
+
+  const auth = app.get('auth');
+  const entity = (auth && auth.entity) || 'user';
+
+  const params = method === 'get'
+  ? hook.params
+  : {
+    query: {},
+    provider: hook.params.provider,
+    authenticated: hook.params.authenticated,
+    [entity]: hook.params[entity],
+    _populate: 'skip'
+  };
+
+  params.query[SKIP] = true;
+
+  const doc = await service.get(id, params);
+
+  delete params.query[SKIP];
+
+  if (doc[field]) {
+    throw new NotFound(`Record for id '${id}' has been soft deleted.`);
+  }
+
+  return doc;
+}
+
+/******************************************************************************/
+// Export
+/******************************************************************************/
+
+export default function (config) {
+  const opt = validate(config);
+
+  return async function (hook) {
     checkContext(hook, 'before', null, 'softDelete');
 
-    if (hook.params.query.$disableSoftDelete) {
-      delete hook.params.query.$disableSoftDelete;
+    const { method, service } = hook;
+
+    hook.params.query = hook.params.query || {};
+
+    if (hook.params.query[SKIP]) {
+      delete hook.params.query[SKIP];
       return hook;
     }
 
-    switch (hook.method) {
+    switch (method) {
       case 'find':
-        hook.params.query[deleteField] = { $ne: true };
-        return hook;
+        hook.params.query[opt.field] = NOT_DELETED;
+        break;
+
       case 'get':
-        return throwIfItemDeleted(hook.id, true)
-          .then(data => {
-            hook.result = data;
-            return hook;
-          });
-      case 'create':
-        return hook;
+        hook.result = await throwIfDeleted(hook, opt);
+        break;
+
       case 'update': // fall through
       case 'patch':
         if (hook.id !== null) {
-          return throwIfItemDeleted(hook.id)
-            .then(() => hook);
+          await throwIfDeleted(hook, opt);
         }
-        hook.params.query[deleteField] = { $ne: true };
-        return hook;
+        hook.params.query[opt.field] = NOT_DELETED;
+        break;
+
       case 'remove':
-        return Promise.resolve()
-          .then(() => hook.id ? throwIfItemDeleted(hook.id) : null)
-          .then(() => {
-            hook.data[deleteField] = true;
-            hook.params.query[deleteField] = { $ne: true };
-            hook.params.query.$disableSoftDelete = true;
+        if (hook.id) {
+          await throwIfDeleted(hook, opt);
+        }
 
-            return service.patch(hook.id, hook.data, hook.params)
-              .then(result => {
-                hook.result = result;
-                return hook;
-              });
-          });
+        hook.data = hook.data || {};
+        hook.data[opt.field] = await opt.setDeleted(hook);
+        if (!hook.data[opt.field]) {
+          throw new Error('config.setDeleted must return a truthy value.');
+        }
+
+        hook.params.query[opt.field] = NOT_DELETED;
+        hook.params.query[SKIP] = true;
+
+        hook.result = await service.patch(hook.id, hook.data, hook.params);
+
+        break;
+
+      case 'create':
+      // No soft deleting needs to happen on reate
+        break;
     }
 
-    function throwIfItemDeleted (id, isGet) {
-      const params = isGet ? hook.params : {
-        query: {},
-        provider: hook.params.provider,
-        authenticated: hook.params.authenticated,
-        user: hook.params.user
-      };
-
-      params.query.$disableSoftDelete = true;
-
-      return service.get(id, params)
-        .then(data => {
-          delete params.query.$disableSoftDelete;
-
-          if (data[deleteField]) {
-            throw new errors.NotFound('Item has been soft deleted.');
-          }
-          return data;
-        })
-        .catch(() => {
-          throw new errors.NotFound('Item not found.');
-        });
-    }
+    return hook;
   };
 }


### PR DESCRIPTION
soft delete can now take a string or an object as configuration,
exposing an additional field: setDeleted

setDeleted allows you to specify a function that returns a value that
will be used when a record is soft deleted

use case examples would be a date object or the id of a user that
triggered the deletion.

setDeleted checks to ensure the value returned is truthy, and may be
asynchronous.

Other notes:
- tests refactored, no longer throw promise warnings.
- removed deprecated babel-preset-es2015 in favour of babel-preset-env.
I'm aware that feathers.js is planning on removing babel, but for the
time being this prevents another deprecation warning.
- soft-delete now tries to look for a custom authentication entity
field before defaulting to 'user' in the 'throwIfDeleted' subroutine.