### PR TITLE
Obsolete error message

### DIFF
--- a/src/services/discard.js
+++ b/src/services/discard.js
@@ -5,7 +5,7 @@ import getItems from './get-items';
 
 export default function (...fieldNames) {
   return hook => {
-    checkContextIf(hook, 'before', ['create', 'update', 'patch'], 'delete');
+    checkContextIf(hook, 'before', ['create', 'update', 'patch'], 'discard');
 
     _remove(getItems(hook), fieldNames);
 


### PR DESCRIPTION
As i can see, this hook was renamed from 'delete' to 'discard', while the error message forming name still have it's old value.
I'm getting this trace:

    error:  Error: The 'delete' hook can only be used on the '["create","update","patch"]' service method(s).
        at exports.default (/home/aquajet/projects/mfo/api/node_modules/feathers-hooks-common/lib/services/check-context.js:24:11)
        at exports.default (/home/aquajet/projects/mfo/api/node_modules/feathers-hooks-common/lib/services/check-context-if.js:9:32)
        at Object.<anonymous> (/home/aquajet/projects/mfo/api/node_modules/feathers-hooks-common/lib/services/discard.js:13:34)
