### PR TITLE
Add alterItems hook with imperative API

### DIFF
--- a/lib/services/alter-items.js
+++ b/lib/services/alter-items.js
@@ -1,0 +1,18 @@
+
+const errors = require('@feathersjs/errors');
+const getItems = require('./get-items');
+const replaceItems = require('./replace-items');
+
+module.exports = function (func) {
+  if (typeof func !== 'function') {
+    throw new errors.BadRequest('Function required. (alter)');
+  }
+
+  return context => {
+    const items = getItems(context);
+    (Array.isArray(items) ? items : [items]).forEach(item => { func(item, context); });
+    replaceItems(context, items);
+
+    return context;
+  };
+};

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -1,5 +1,6 @@
 
 const _conditionals = require('../common/_conditionals');
+const alterItems = require('./alter-items');
 const callbackToPromise = require('./callback-to-promise');
 const checkContext = require('./check-context');
 const checkContextIf = require('./check-context-if');
@@ -50,6 +51,7 @@ const conditionals = _conditionals(
   });
 
 module.exports = Object.assign({ callbackToPromise,
+  alterItems,
   checkContext,
   checkContextIf,
   client,

--- a/tests/services/alter-items.test.js
+++ b/tests/services/alter-items.test.js
@@ -1,0 +1,69 @@
+
+const { assert } = require('chai');
+const { alterItems } = require('../../lib/services');
+
+let hookBefore;
+let hookAfter;
+let hookFindPaginate;
+let hookFind;
+
+describe('services alterItems', () => {
+  beforeEach(() => {
+    hookBefore = {
+      type: 'before',
+      method: 'create',
+      params: { provider: 'rest' },
+      data: { first: 'John', last: 'Doe' } };
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      result: { first: 'Jane', last: 'Doe' } };
+    hookFindPaginate = {
+      type: 'after',
+      method: 'find',
+      params: { provider: 'rest' },
+      result: {
+        total: 2,
+        data: [
+          { first: 'John', last: 'Doe' },
+          { first: 'Jane', last: 'Doe' }
+        ]
+      } };
+    hookFind = {
+      type: 'after',
+      method: 'find',
+      params: { provider: 'rest' },
+      result: [
+        { first: 'John', last: 'Doe' },
+        { first: 'Jane', last: 'Doe' }
+      ]
+    };
+  });
+
+  it('updates hook before::create', () => {
+    alterItems(rec => { rec.state = 'UT'; })(hookBefore);
+    assert.deepEqual(hookBefore.data, { first: 'John', last: 'Doe', state: 'UT' });
+  });
+
+  it('updates hook after::find with pagination', () => {
+    alterItems(rec => { delete rec.last; })(hookFindPaginate);
+    assert.deepEqual(hookFindPaginate.result.data, [
+      { first: 'John' },
+      { first: 'Jane' }
+    ]);
+  });
+
+  it('updates hook after::find with no pagination', () => {
+    alterItems(rec => { rec.new = rec.first; })(hookFind);
+    assert.deepEqual(hookFind.result, [
+      { first: 'John', last: 'Doe', new: 'John' },
+      { first: 'Jane', last: 'Doe', new: 'Jane' }
+    ]);
+  });
+
+  it('updates hook after', () => {
+    alterItems(rec => { rec.new = rec.first; })(hookAfter);
+    assert.deepEqual(hookAfter.result, { first: 'Jane', last: 'Doe', new: 'Jane' });
+  });
+});

--- a/tests/services/exposed.js
+++ b/tests/services/exposed.js
@@ -1,8 +1,9 @@
 
 const { assert } = require('chai');
-const hooks = require('../../lib');
+const hooks = require('../../lib/index');
 
 const hookNames = [
+  'alterItems',
   'callbackToPromise',
   'checkContext',
   'checkContextIf',


### PR DESCRIPTION
A declarative style API requires so many hooks. This one imperative style API can replace most of the trivial declarative hooks.