### PR TITLE
Fix feathersErrors.errors === undefined error

### DIFF
--- a/lib/services/disallow.js
+++ b/lib/services/disallow.js
@@ -1,7 +1,7 @@
 
 const feathersErrors = require('@feathersjs/errors');
 
-const errors = feathersErrors.errors;
+const errors = feathersErrors;
 
 module.exports = function (...providers) {
   return context => {


### PR DESCRIPTION
### Summary
When disallowing a route through `disallow('external')`, this error occurs:
```
TypeError: Cannot read property 'MethodNotAllowed' of undefined
    at Object.context ([path]/feathers-hooks-common/lib/services/disallow.js:18:24)
```
That may be due to a possible change in @feathersjs/errors. In the current version, error functions like `MethodNotAllowed` reside on the `feathersErrors` object itself instead of `feathersErrors.errors`.

### Other Information
All tests passed.