### PR TITLE
Modify keep hook to only ignore undefined values.

### DIFF
--- a/lib/services/keep.js
+++ b/lib/services/keep.js
@@ -1,6 +1,7 @@
 const checkContextIf = require('./check-context-if');
 const getItems = require('./get-items');
 const replaceItems = require('./replace-items');
+const existsByDot = require('../common/exists-by-dot');
 const getByDot = require('../common/get-by-dot');
 const setByDot = require('../common/set-by-dot');
 
@@ -22,10 +23,10 @@ module.exports = function (...fieldNames) {
 function replaceItem (item, fields) {
   const newItem = {};
   fields.forEach(field => {
+    if (!existsByDot(item, field)) return;
+
     const value = getByDot(item, field);
-    if (typeof value !== 'undefined' && value !== null) {
-      setByDot(newItem, field, value);
-    }
+    setByDot(newItem, field, value);
   });
   item = newItem;
   return item;

--- a/lib/services/keep.js
+++ b/lib/services/keep.js
@@ -23,7 +23,7 @@ function replaceItem (item, fields) {
   const newItem = {};
   fields.forEach(field => {
     const value = getByDot(item, field);
-    if (typeof value !== 'undefined') {
+    if (typeof value !== 'undefined' && value !== null) {
       setByDot(newItem, field, value);
     }
   });

--- a/lib/services/keep.js
+++ b/lib/services/keep.js
@@ -23,7 +23,7 @@ function replaceItem (item, fields) {
   const newItem = {};
   fields.forEach(field => {
     const value = getByDot(item, field);
-    if (value) {
+    if (typeof value !== 'undefined') {
       setByDot(newItem, field, value);
     }
   });

--- a/tests/services/keep.test.js
+++ b/tests/services/keep.test.js
@@ -87,24 +87,54 @@ describe('services keep', () => {
       assert.deepEqual(hook.data, { last: 'Doe' });
     });
 
-    it('does not throw if field is undefined', () => {
+    it('keeps undefined values', () => {
       const hook = {
         type: 'before',
         method: 'create',
         params: { provider: 'rest' },
         data: { first: undefined, last: 'Doe' } };
       hooks.keep('first')(hook);
-      assert.deepEqual(hook.data, {}); // todo note this
+      assert.deepEqual(hook.data, { first: undefined });
     });
 
-    it('does not throw if field is null', () => {
+    it('keeps null values', () => {
       const hook = {
         type: 'before',
         method: 'create',
         params: { provider: 'rest' },
         data: { first: null, last: 'Doe' } };
       hooks.keep('first')(hook);
-      assert.deepEqual(hook.data, {});
+      assert.deepEqual(hook.data, { first: null });
+    });
+
+    it('keeps false values', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: false, last: 'Doe' } };
+      hooks.keep('first')(hook);
+      assert.deepEqual(hook.data, { first: false });
+    });
+
+    it('keeps 0 values', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: 0, last: 'Doe' } };
+      hooks.keep('first')(hook);
+      assert.deepEqual(hook.data, { first: 0 });
+    });
+
+    it('keeps empty string values', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: '', last: 'Doe' } };
+      hooks.keep('first')(hook);
+      assert.deepEqual(hook.data, { first: '' });
     });
   });
 


### PR DESCRIPTION
### Summary

Problem: keep is discarding properties if they have "falsey" values.

Solution: keep now only discards undefined values. As a result a 0 or empty string can now reach the service.
