### PR TITLE
Verify deprecated syntax outside the hook function

### DIFF
--- a/lib/services/prevent-changes.js
+++ b/lib/services/prevent-changes.js
@@ -5,15 +5,19 @@ const checkContext = require('./check-context');
 const errors = require('@feathersjs/errors');
 
 module.exports = function (...fieldNames) {
+  const ifThrow = fieldNames[0];
+  const deprecated = typeof ifThrow === 'string'
+
+  if (!deprecated) {
+    fieldNames = fieldNames.slice(1);
+  }
+
   return context => {
     checkContext(context, 'before', ['patch'], 'preventChanges');
     const data = context.data;
-    const ifThrow = fieldNames[0];
 
-    if (typeof ifThrow === 'string') {
+    if (deprecated) {
       console.log('**Deprecated** Use the preventChanges(true, ...fieldNames) syntax instead.');
-    } else {
-      fieldNames = fieldNames.slice(1);
     }
 
     fieldNames.forEach(name => {


### PR DESCRIPTION
Hi, 
I think it's better to set `fieldNames` outside the hook function. The current version makes `fieldNames[0]` to always be a string after `fieldNames = fieldNames.slice(1);`. So even if the developer uses the `preventChanges(true, ...fieldNames)` syntax, the hook will log the deprecated warning.
With this solution, the warning will be logged only if the developer is using the deprecated syntax.