### PR TITLE
close #308, add disableMultiItemCreate

### DIFF
--- a/lib/services/disable-multi-item-create.js
+++ b/lib/services/disable-multi-item-create.js
@@ -1,0 +1,15 @@
+
+const errors = require('@feathersjs/errors');
+const checkContext = require('./check-context');
+
+module.exports = function () {
+  return function (context) {
+    checkContext(context, 'before', ['create'], 'disableMultiItemCreate');
+
+    if (Array.isArray(context.data)) {
+      throw new errors.BadRequest(
+        `Multi-record creations not allowed for ${context.path} ${context.method}. (disableMultiItemCreate)`
+      );
+    }
+  };
+};

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -12,6 +12,7 @@ const deleteByDot = require('../common/delete-by-dot');
 const dePopulate = require('./de-populate');
 const disable = require('./disable');
 const disableMultiItemChange = require('./disable-multi-item-change');
+const disableMultiItemCreate = require('./disable-multi-item-create');
 const disablePagination = require('./disable-pagination');
 const disallow = require('./disallow');
 const discard = require('./discard');
@@ -67,6 +68,7 @@ module.exports = Object.assign({ callbackToPromise,
   dePopulate,
   disable,
   disableMultiItemChange,
+  disableMultiItemCreate,
   disablePagination,
   disallow,
   discard,

--- a/tests/services/disable-multi-item-create.test.js
+++ b/tests/services/disable-multi-item-create.test.js
@@ -1,0 +1,56 @@
+
+const {
+  assert
+} = require('chai');
+
+const {
+  disableMultiItemCreate
+} = require('../../lib/services');
+
+var hookBefore;
+
+['create'].forEach(method => {
+  describe(`services disableMultiItemCreate - ${method}`, () => {
+    beforeEach(() => {
+      hookBefore = {
+        type: 'before',
+        method,
+        params: { provider: 'rest' }
+      };
+    });
+
+    it('allows non-array data', () => {
+      hookBefore.data = { first: 'John', last: 'Doe' };
+
+      const result = disableMultiItemCreate()(hookBefore);
+      assert.equal(result, undefined);
+    });
+
+    it('throws on array data', () => {
+      hookBefore.data = [{ first: 'John', last: 'Doe' }, { first: 'John', last: 'Doe' }];
+
+      assert.throws(() => { disableMultiItemCreate()(hookBefore); });
+    });
+
+    it('throws if after hook', () => {
+      hookBefore.data = { first: 'John', last: 'Doe' };
+      hookBefore.type = 'after';
+
+      assert.throws(() => { disableMultiItemCreate()(hookBefore); });
+    });
+  });
+});
+
+['find', 'get', 'update', 'patch', 'remove'].forEach(method => {
+  ['before', 'after'].forEach(type => {
+    describe(`services disableMultiItemCreate - ${method} ${type}`, () => {
+      it('throws', () => {
+        hookBefore.data = { first: 'John', last: 'Doe' };
+        hookBefore.method = method;
+        hookBefore.type = type;
+
+        assert.throws(() => { disableMultiItemCreate()(hookBefore); });
+      });
+    });
+  });
+});

--- a/tests/services/exposed.js
+++ b/tests/services/exposed.js
@@ -15,6 +15,7 @@ const hookNames = [
   'dePopulate',
   'disable',
   'disableMultiItemChange',
+  'disableMultiItemCreate',
   'disablePagination',
   'disallow',
   'discard',


### PR DESCRIPTION
Finally got some time to pick up my previous trivial ideas on #308. Just add `disableMultiItemCreate` just like `disableMultiItemChanges`.

Tests are added and passed.  