### PR TITLE
Improve alterItems hook: can map to a newly created object

### DIFF
--- a/lib/services/alter-items.js
+++ b/lib/services/alter-items.js
@@ -18,7 +18,7 @@ module.exports = function (func) {
     (isArray ? items : [items]).forEach(
       (item, index) => {
         const result = func(item, context);
-        if (result != null) {
+        if (typeof result === 'object' && result !== null) {
           if (isArray) {
             items[index] = result;
           } else {

--- a/lib/services/alter-items.js
+++ b/lib/services/alter-items.js
@@ -13,8 +13,20 @@ module.exports = function (func) {
   }
 
   return context => {
-    const items = getItems(context);
-    (Array.isArray(items) ? items : [items]).forEach(item => { func(item, context); });
+    let items = getItems(context);
+    const isArray = Array.isArray(items);
+    (isArray ? items : [items]).forEach(
+      (item, index) => {
+        const result = func(item, context);
+        if (result != null) {
+          if (isArray) {
+            items[index] = result;
+          } else {
+            items = result;
+          }
+        }
+      }
+    );
     const isDone = replaceItems(context, items);
 
     if (!isDone || typeof isDone.then !== 'function') {

--- a/tests/services/alter-items.test.js
+++ b/tests/services/alter-items.test.js
@@ -78,4 +78,30 @@ describe('services alterItems', () => {
     alterItems(rec => { rec.new = rec.first; })(hookAfter);
     assert.deepEqual(hookAfter.result, { first: 'Jane', last: 'Doe', new: 'Jane' });
   });
+
+  it('updates hook before::create with new item returned', () => {
+    alterItems(rec => Object.assign({}, rec, { state: 'UT' }))(hookBefore);
+    assert.deepEqual(hookBefore.data, { first: 'John', last: 'Doe', state: 'UT' });
+  });
+
+  it('updates hook after::find with pagination with new item returned', () => {
+    alterItems(rec => Object.assign({}, { first: rec.first }))(hookFindPaginate);
+    assert.deepEqual(hookFindPaginate.result.data, [
+      { first: 'John' },
+      { first: 'Jane' }
+    ]);
+  });
+
+  it('updates hook after::find with no pagination with new item returned', () => {
+    alterItems(rec => Object.assign({}, rec, { new: rec.first }))(hookFind);
+    assert.deepEqual(hookFind.result, [
+      { first: 'John', last: 'Doe', new: 'John' },
+      { first: 'Jane', last: 'Doe', new: 'Jane' }
+    ]);
+  });
+
+  it('updates hook after with new item returned', () => {
+    alterItems(rec => Object.assign({}, rec, { new: rec.first }))(hookAfter);
+    assert.deepEqual(hookAfter.result, { first: 'Jane', last: 'Doe', new: 'Jane' });
+  });
 });


### PR DESCRIPTION
Previously `alterItems` only accept a function that use `item` as a reference, and we have to create/mutate/delete properties. upon the original reference This makes a bunch of `lodash` tools unusable, since most `lodash` functions return a new object rather than changing the original input.

This PR allows `alterItems` accepting a function with a returned value. If the function returns a non-null value, the original item/items are replaced with the returned value; if the function returns nothing, just keep the previous behavior. 

Example: 

```js
alterItems(item => {
  return _.omit(item, ['a', 'b', 'c'])
}
```
Please check the code and the tests with caution in case I make some terrible mistakes. ;)