### PR TITLE
Improve keep hook: allow passing in a function (item, context) => fields

### DIFF
--- a/lib/services/keep.js
+++ b/lib/services/keep.js
@@ -5,20 +5,28 @@ const existsByDot = require('../common/exists-by-dot');
 const getByDot = require('../common/get-by-dot');
 const setByDot = require('../common/set-by-dot');
 
-module.exports = function (...fieldNames) {
+module.exports = function (...fieldNamesOrFunc) {
   return context => {
     checkContextIf(context, 'before', ['create', 'update', 'patch'], 'keep');
     const items = getItems(context);
 
     if (Array.isArray(items)) {
-      replaceItems(context, items.map(item => replaceItem(item, fieldNames)));
+      replaceItems(context, items.map(item => replaceItem(item, getFieldNames(fieldNamesOrFunc, item, context))));
     } else {
-      replaceItems(context, replaceItem(items, fieldNames));
+      replaceItems(context, replaceItem(items, getFieldNames(fieldNamesOrFunc, items, context)));
     }
 
     return context;
   };
 };
+
+function getFieldNames (fieldNamesOrFunc, item, context) {
+  if (typeof fieldNamesOrFunc[0] === 'function') {
+    const result = fieldNamesOrFunc[0](item, context);
+    return Array.isArray(result) ? result : [result];
+  }
+  return fieldNamesOrFunc;
+}
 
 function replaceItem (item, fields) {
   const newItem = {};

--- a/tests/services/keep.test.js
+++ b/tests/services/keep.test.js
@@ -136,6 +136,98 @@ describe('services keep', () => {
       hooks.keep('first')(hook);
       assert.deepEqual(hook.data, { first: '' });
     });
+
+    it('updates hook before::create, with function', () => {
+      hooks.keep((item, context) => 'last')(hookBefore);
+      assert.deepEqual(hookBefore.data, { last: 'Doe' });
+    });
+
+    it('updates hook after::find with pagination, with function', () => {
+      hooks.keep((item, context) => 'first')(hookFindPaginate);
+      assert.deepEqual(hookFindPaginate.result.data, [
+        { first: 'John' },
+        { first: 'Jane' }
+      ]);
+    });
+
+    it('updates hook after::find with no pagination, with function', () => {
+      hooks.keep((item, context) => 'first')(hookFind);
+      assert.deepEqual(hookFind.result, [
+        { first: 'John' },
+        { first: 'Jane' }
+      ]);
+    });
+
+    it('updates hook after, with function', () => {
+      hooks.keep((item, context) => 'first')(hookAfter);
+      assert.deepEqual(hookAfter.result, { first: 'Jane' });
+    });
+
+    it('updates when called internally on server, with function', () => {
+      hookAfter.params.provider = '';
+      hooks.keep((item, context) => 'first')(hookAfter);
+      assert.deepEqual(hookAfter.result, { first: 'Jane' });
+    });
+
+    it('does not throw if field is missing, with function', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: 'John', last: 'Doe' } };
+      hooks.keep((item, context) => 'last', 'xx')(hook);
+      assert.deepEqual(hook.data, { last: 'Doe' });
+    });
+
+    it('keeps undefined values, with function', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: undefined, last: 'Doe' } };
+      hooks.keep((item, context) => 'first')(hook);
+      assert.deepEqual(hook.data, { first: undefined });
+    });
+
+    it('keeps null values, with function', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: null, last: 'Doe' } };
+      hooks.keep((item, context) => 'first')(hook);
+      assert.deepEqual(hook.data, { first: null });
+    });
+
+    it('keeps false values, with function', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: false, last: 'Doe' } };
+      hooks.keep((item, context) => 'first')(hook);
+      assert.deepEqual(hook.data, { first: false });
+    });
+
+    it('keeps 0 values, with function', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: 0, last: 'Doe' } };
+      hooks.keep((item, context) => 'first')(hook);
+      assert.deepEqual(hook.data, { first: 0 });
+    });
+
+    it('keeps empty string values, with function', () => {
+      const hook = {
+        type: 'before',
+        method: 'create',
+        params: { provider: 'rest' },
+        data: { first: '', last: 'Doe' } };
+      hooks.keep((item, context) => 'first')(hook);
+      assert.deepEqual(hook.data, { first: '' });
+    });
   });
 
   describe('handles dot notation', () => {
@@ -178,6 +270,39 @@ describe('services keep', () => {
 
     it('ignores bad or missing no dot path', () => {
       hooks.keep('xx')(hookBefore);
+      assert.deepEqual(hookBefore.data, {});
+    });
+
+    it('prop with no dots, with function', () => {
+      hooks.keep((item, context) => 'empl')(hookBefore);
+      assert.deepEqual(hookBefore.data,
+        { empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' } }
+      );
+    });
+
+    it('prop with 1 dot, with function', () => {
+      hooks.keep((item, context) => ['empl.name', 'dept'])(hookBefore);
+      assert.deepEqual(hookBefore.data,
+        { empl: { name: { first: 'John', last: 'Doe' } }, dept: 'Acct' }
+      );
+    });
+
+    it('prop with 2 dots, with function', () => {
+      hooks.keep((item, context) => ['empl.name.last', 'empl.status', 'dept'])(hookBefore);
+      assert.deepEqual(hookBefore.data,
+        { empl: { name: { last: 'Doe' }, status: 'AA' }, dept: 'Acct' }
+      );
+    });
+
+    it('ignores bad or missing paths, with function', () => {
+      hooks.keep((item, context) => ['empl.name.first', 'empl.name.surname'])(hookBefore);
+      assert.deepEqual(hookBefore.data,
+        { empl: { name: { first: 'John' } } }
+      );
+    });
+
+    it('ignores bad or missing no dot path, with function', () => {
+      hooks.keep((item, context) => ['xx'])(hookBefore);
       assert.deepEqual(hookBefore.data, {});
     });
   });


### PR DESCRIPTION
Sometimes we need to dynamically determine which fields to keep according to the current item and context. This PR allows the `keep` hook to accept a function to dynamically generate field names. Example:

```js
keep((item, context) => 
  context.method === 'update' ? item.fieldsToKeep : ['_id', 'name']
)
```