### PR TITLE
Fixed issue #337 and included relevant test - ignore missing id when …

### DIFF
--- a/lib/services/stash-before.js
+++ b/lib/services/stash-before.js
@@ -8,7 +8,7 @@ module.exports = function (prop) {
   return context => {
     checkContext(context, 'before', ['get', 'update', 'patch', 'remove'], 'stashBefore');
 
-    if (context.id === null || context.id === undefined) {
+    if ((context.id === null || context.id === undefined) && !context.params.query) {
       throw new errors.BadRequest('Id is required. (stashBefore)');
     }
 

--- a/lib/services/stash-before.js
+++ b/lib/services/stash-before.js
@@ -8,13 +8,13 @@ module.exports = function (prop) {
   return context => {
     checkContext(context, 'before', ['get', 'update', 'patch', 'remove'], 'stashBefore');
 
-    if ((context.id === null || context.id === undefined) && !context.params.query) {
-      throw new errors.BadRequest('Id is required. (stashBefore)');
-    }
-
     if (context.params.query && context.params.query.$disableStashBefore) {
       delete context.params.query.$disableStashBefore;
       return context;
+    }
+
+    if ((context.id === null || context.id === undefined) && !context.params.query) {
+      throw new errors.BadRequest('Id is required. (stashBefore)');
     }
 
     const params = context.method === 'get' ? context.params : {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-hooks-common",
-  "version": "3.10.0",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-hooks-common",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Useful hooks for use with Feathersjs services.",
   "main": "lib/",
   "directories": {

--- a/tests/services/stash-before.test.js
+++ b/tests/services/stash-before.test.js
@@ -70,6 +70,13 @@ describe('services stash-before', () => {
     });
   });
 
+  it(`Do not stash when query is used in remove`, () => {
+    return users.remove(null, {query: {}})
+      .then(() => {
+        assert.notProperty(finalParams, 'before');
+      });
+  });
+
   ['create', 'find'].forEach(method => {
     it(`throws on ${method}`, done => {
       users[method]({})


### PR DESCRIPTION
…query is used.

### Summary

PR fixess issue #337 
StashBefore now does not throw an error when the id is missing but a query parameter is present. 
Test script was updated with a scenario where all documents are removed, by passing no id and an empty query object.