### PR TITLE
Opinionated fix for #345

### DIFF
--- a/lib/services/soft-delete.js
+++ b/lib/services/soft-delete.js
@@ -11,7 +11,7 @@ module.exports = function (field) {
     context.params.query = context.params.query || {};
     checkContext(context, 'before', null, 'softDelete');
 
-    if (context.params.query.$disableSoftDelete) {
+    if (context.params.query && context.params.query.$disableSoftDelete) {
       delete context.params.query.$disableSoftDelete;
       return context;
     }
@@ -23,6 +23,7 @@ module.exports = function (field) {
       case 'get':
         return throwIfItemDeleted(context.id, true)
           .then(data => {
+            context.params.before = data;
             context.result = data;
             return context;
           });
@@ -53,6 +54,10 @@ module.exports = function (field) {
     }
 
     function throwIfItemDeleted (id, isGet) {
+      if (context.params.before && context.params.before.id === id) {
+        return Promise.resolve(context.params.before);
+      }
+
       const params = isGet ? context.params : {
         query: {},
         provider: context.params.provider,

--- a/lib/services/stash-before.js
+++ b/lib/services/stash-before.js
@@ -17,6 +17,11 @@ module.exports = function (prop) {
       throw new errors.BadRequest('Id is required. (stashBefore)');
     }
 
+    if (context.params.before && context.params.before.id === context.id) {
+      context.params[beforeField] = context.params.before;
+      return context;
+    }
+
     const params = context.method === 'get' ? context.params : {
       provider: context.params.provider,
       authenticated: context.params.authenticated,
@@ -30,7 +35,9 @@ module.exports = function (prop) {
       .then(data => {
         delete params.query.$disableStashBefore;
 
-        context.params[beforeField] = JSON.parse(JSON.stringify(data));
+        const dataObject = JSON.parse(JSON.stringify(data));
+        context.params[beforeField] = dataObject;
+        context.params.before = dataObject;
         return context;
       })
       .catch(() => context);


### PR DESCRIPTION
### Summary

This pull requests fixes the following problems
1. Issue #345 
2. Multiple GET requests made by hooks for the same document

I introduced a new field, `context.params.before`, to stash the GET response and have the hooks check for it before proceeding further. I don't know how this will affect other hooks in the ecosystem, but I'd like to hear your take on it.