### PR TITLE
allow mongoKeys running for all methods

### DIFF
--- a/lib/services/mongo-keys.js
+++ b/lib/services/mongo-keys.js
@@ -15,7 +15,7 @@ module.exports = function mongoKeys (ObjectID, keyFields) {
   });
 
   return context => {
-    checkContext(context, 'before', ['find', 'update', 'patch', 'remove'], 'mongoKeys');
+    checkContext(context, 'before', null, 'mongoKeys');
     const query = context.params.query || {};
 
     traverse(query).forEach(function (node) {


### PR DESCRIPTION
following #362 

I found sometimes `get` and `create` methods may also have `params.query`. For example, people may use `query` to pluck fields to return: `service.get(id, {query: {$select: [...]}}`. More generally, since `params.query` is the only way to transfer customized params from client to server, people may use it in all methods, including `create` and `get`, to do some tricky things. 

So there is no reason to forbid `mongoKeys` to run in `get` and `create`. 