### PR TITLE
alterItems now works with an async callback function

### DIFF
--- a/lib/services/alter-items.js
+++ b/lib/services/alter-items.js
@@ -5,7 +5,7 @@ const replaceItems = require('./replace-items');
 
 module.exports = function (func) {
   if (!func) {
-    func = () => {};
+    func = () => { };
   }
 
   if (typeof func !== 'function') {
@@ -16,9 +16,14 @@ module.exports = function (func) {
     let items = getItems(context);
     const isArray = Array.isArray(items);
 
-    (isArray ? items : [items]).forEach(
-      (item, index) => {
-        const result = func(item, context);
+    const promises = (isArray ? items : [items]).map(
+      async (item, index) => {
+        let result = func(item, context);
+
+        if (result && typeof result.then === 'function') {
+          result = await result
+        }
+
         if (typeof result === 'object' && result !== null) {
           if (isArray) {
             items[index] = result;
@@ -29,7 +34,8 @@ module.exports = function (func) {
       }
     );
 
-    replaceItems(context, items);
-    return context;
+    return Promise.all(promises)
+      .then(() => replaceItems(context, items))
+      .then(() => context)
   };
 };

--- a/lib/services/alter-items.js
+++ b/lib/services/alter-items.js
@@ -1,4 +1,3 @@
-
 const errors = require('@feathersjs/errors');
 const getItems = require('./get-items');
 const replaceItems = require('./replace-items');
@@ -17,20 +16,24 @@ module.exports = function (func) {
     const isArray = Array.isArray(items);
 
     const promises = (isArray ? items : [items]).map(
-      async (item, index) => {
-        let result = func(item, context);
+      (item, index) => {
+        let resultPromise = func(item, context);
 
-        if (result && typeof result.then === 'function') {
-          result = await result
+        // If the result is not a promise, wrap it in one
+        if (!resultPromise || typeof resultPromise.then !== 'function') {
+          resultPromise = Promise.resolve(resultPromise)
         }
 
-        if (typeof result === 'object' && result !== null) {
-          if (isArray) {
-            items[index] = result;
-          } else {
-            items = result;
+        return resultPromise.then(result => {
+          if (typeof result === 'object' && result !== null) {
+            if (isArray) {
+              items[index] = result;
+            } else {
+              items = result;
+            }
           }
-        }
+        })
+
       }
     );
 


### PR DESCRIPTION
### Summary

alterItems did not work with a async callback function. See https://github.com/feathers-plus/feathers-hooks-common/issues/367
This PR fixes #367 

Documentation at: https://github.com/feathers-plus/docs/pull/19