### PR TITLE
Fix deletion of array items

### DIFF
--- a/lib/common/delete-by-dot.js
+++ b/lib/common/delete-by-dot.js
@@ -16,5 +16,10 @@ module.exports = function (obj, path) {
     }
   }
 
-  delete obj[parts[nonLeafLen]];
+  if(Array.isArray(obj)){
+    obj.splice(parts[nonLeafLen],1);
+  }
+  else{
+    delete obj[parts[nonLeafLen]];
+  }
 };

--- a/tests/services/delete-by-dot.test.js
+++ b/tests/services/delete-by-dot.test.js
@@ -50,6 +50,13 @@ describe('test deleteByDot', () => {
     assert.deepEqual(obj, {});
   });
 
+  it('delete an array item', ()=> {
+    let obj1 = {arr:['a', 'b', 'c']};
+    deleteByDot(obj1, 'arr.1');
+    assert.equal(obj1.arr[1], 'c');
+    assert.equal(obj1.arr.length, 2);
+  });
+
   it('does not throw if path ends prematurely', () => {
     deleteByDot(obj, 'x');
     assert.deepEqual(obj, objTest, '1');


### PR DESCRIPTION
### Problem
The `delete` operator is used to remove properties from objects and items from arrays. When `delete` is used on an array, the item is removed, but the array is not re-indexed;

```JS
let a=[1,2,3,4];
delete a[1];

// a now equals [1,,3,4]
```
If deleteByDot is used on an array that subsequently stored through a feathers service, the resulting array in the database (using the mongoose driver, at least) results in the "deleted" item being replaced with `null` rather than being completely removed. 

### Proposed Solution
The pull request tests to see if the item to delete is an array. If it is, `splice` is to remove the array item. Otherwise, `delete` is used. 

### Potential Problems
Because this results in different output, it could potentially break code that relies on the current behavior.