### PR TITLE
Fix prevent changes and discard hooks

### DIFF
--- a/lib/common/_remove.js
+++ b/lib/common/_remove.js
@@ -5,6 +5,9 @@ const _transformItems = require('./_transform-items');
 module.exports = function (items /* modified */, fieldNames) {
   _transformItems(items, fieldNames, (item, fieldName, value) => {
     if (value !== undefined) {
+      // Delete fields like item['contactPerson.name']. This is a typical patch format for MongoDB.
+      if(item[fieldName]) delete item[fieldName];
+      // Delete fields like item.contactPerson.name
       deleteByDot(item, fieldName);
     }
   });

--- a/lib/services/prevent-changes.js
+++ b/lib/services/prevent-changes.js
@@ -18,15 +18,15 @@ module.exports = function (...fieldNames) {
     const data = context.data;
 
     fieldNames.forEach(name => {
-      // Delete data['contactPerson.name']
-      if(data[name]) {
-          delete data[name];
-      }
-      // Delete data.contactPerson.name
-
       if (existsByDot(data, name)) {
         if (ifThrow) throw new errors.BadRequest(`Field ${name} may not be patched. (preventChanges)`);
+        // Delete data.contactPerson.name
         deleteByDot(data, name);
+      }
+      // Delete data['contactPerson.name']
+      if (data[name]) {
+        if (ifThrow) throw new errors.BadRequest(`Field ${name} may not be patched. (preventChanges)`);
+        delete data[name];
       }
     });
 

--- a/lib/services/prevent-changes.js
+++ b/lib/services/prevent-changes.js
@@ -18,6 +18,12 @@ module.exports = function (...fieldNames) {
     const data = context.data;
 
     fieldNames.forEach(name => {
+      // Delete data['contactPerson.name']
+      if(data[name]) {
+          delete data[name];
+      }
+      // Delete data.contactPerson.name
+
       if (existsByDot(data, name)) {
         if (ifThrow) throw new errors.BadRequest(`Field ${name} may not be patched. (preventChanges)`);
         deleteByDot(data, name);

--- a/tests/services/prevent-changes.test.js
+++ b/tests/services/prevent-changes.test.js
@@ -37,7 +37,7 @@ describe('services preventChanges', () => {
         type: 'before',
         method: 'patch',
         params: { provider: 'rest' },
-        data: { first: 'John', last: 'Doe', a: { b: undefined, c: { d: { e: 1 } } } } };
+        data: { first: 'John', last: 'Doe', 'name.first': 'John', a: { b: undefined, c: { d: { e: 1 } } } } };
     });
 
     it('does not throw if props not found', () => {
@@ -51,6 +51,7 @@ describe('services preventChanges', () => {
       assert.throw(() => preventChanges('name', 'a.b')(hookBefore));
       assert.throw(() => preventChanges('name', 'a.c')(hookBefore));
       assert.throw(() => preventChanges('name', 'a.c.d.e')(hookBefore));
+      assert.throw(() => preventChanges('name.first')(hookBefore));
     });
   });
 


### PR DESCRIPTION
### Summary
Enable the hooks discard and preventChanges to delete properties containing a dot.

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.

**Problem**
This is about nested objects in PATCH requests. A PATCH request for MongoDB can either replace an entire object through a request like this:
`{
  "contactPerson": {
    "lastName": "Doe",
    "firstName" "John"
  }
}`
or it can update an individual property like this:
`{
  "contactPerson.firstName" "Jane"
  }
}`
In the latter case, only the property `firstName` is will be updated, while `lastName` will stay intact.

The MongoDB documentation explains this here: https://docs.mongodb.com/manual/reference/operator/update/set/#up._S_set ([feathers-mongoose](https://github.com/feathersjs-ecosystem/feathers-mongoose) implicitly wraps the object from a PATCH request with a {$set : ...} object).

Currently, however, both `discard('contactPerson.firstName')` and `preventChanges(false, 'contactPerson.firstName')` only catch the first PATCH object and ignore the second one.

**Expectation**
The discard hook would remove both property formats from the PATCH request to prevent updating e. g. passwords, usernames etc.
I would bet that quite a few systems are currently subject to an attack because their owners assume that both discard and preventChanges remove the second PATCH format as well.

**Solution**
Both hooks check whether there is a property containing the dot on the object itself. If so, delete that property.
The previous behavior remains unchanged: The dot notation will **also** traverse the object tree. So, both context.data.contactPerson.firstName and context.data['contactPerson.firstName'] will be caught.

- [ ] Are there any open issues that are related to this? No.
- [ ] Is this PR dependent on PRs in other repos? No.

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: