### PR TITLE
Added callingParams, callingParamsDefault hooks. Replaced makeCallingParams

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,5 @@
+Hook standards for written values so they work on all adapters
+- {Number} boolean: 0,1
+- {Number | null} date: null or Unix data (Date.now())
+- {String} arrays: JSON.stringify(array)
+- {Object} params for called service: default is callingParams()(context)

--- a/lib/services/calling-params.js
+++ b/lib/services/calling-params.js
@@ -1,0 +1,80 @@
+
+const getByDot = require('../common/get-by-dot');
+const setByDot = require('../common/set-by-dot');
+
+const stndAuthProps = ['provider', 'authenticated', 'user']; // feathers-authentication
+// App wide defaults
+const defaults = {
+  propNames: stndAuthProps,
+  newProps: {}
+};
+
+// Set app wide defaults
+function callingParamsDefaults (defaultPropNames = [], defaultNewProps) {
+  if (defaultPropNames) {
+    defaults.propNames = Array.isArray(defaultPropNames) ? defaultPropNames : [defaultPropNames];
+  }
+
+  if (defaultNewProps) {
+    defaults.newProps = defaultNewProps;
+  }
+}
+
+// Utility func for explicit use in hook parameters `callingParams(...)`.
+// It defaults to `callingParams()`.
+function callingParams ({ query, propNames = [], newProps = {}, hooksToDisable = [], ignoreDefaults } = {}) {
+  return context => {
+    propNames = Array.isArray(propNames) ? propNames : [propNames];
+    hooksToDisable = Array.isArray(hooksToDisable) ? hooksToDisable : [hooksToDisable];
+
+    const newParams = query ? { query } : {};
+    const allPropNames = ignoreDefaults ? propNames : [].concat(defaults.propNames, propNames);
+
+    allPropNames.forEach(name => {
+      if (name) { // for makeCallingParams compatibility
+        const value = getByDot(context.params, name);
+
+        if (value !== undefined) {
+          setByDot(newParams, name, value);
+        }
+      }
+    });
+
+    Object.assign(newParams, ignoreDefaults ? {} : defaults.newProps, newProps);
+
+    hooksToDisable.forEach(name => {
+      switch (name) {
+        case 'populate': // fall through
+        case 'fastJoin':
+          newParams._populate = 'skip';
+          break;
+        case 'softDelete':
+          newParams.query = newParams.query || {};
+          newParams.query.$disableSoftDelete = true;
+          break;
+        case 'stashBefore':
+          newParams.query = newParams.query || {};
+          newParams.query.$disableStashBefore = true;
+          break;
+      }
+    });
+
+    return newParams;
+  };
+}
+
+// Function compatible with previous makeCallingParams utility.
+function makeCallingParams (context, query, propNames, newProps = {}) {
+  return callingParams({
+    query,
+    propNames: propNames === undefined ? ['provider', 'authenticated', 'user'] : propNames,
+    newProps: Object.assign({}, { _populate: 'skip' }, newProps),
+    ignoreDefaults: true
+  })(context);
+}
+
+module.exports = {
+  callingParamsDefaults,
+  callingParams,
+  makeCallingParams
+};

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -4,6 +4,7 @@ const { actOnDefault, actOnDispatch } = require('./act-on-dispatch');
 const alterItems = require('./alter-items');
 const cache = require('./cache');
 const callbackToPromise = require('./callback-to-promise');
+const { callingParamsDefaults, callingParams, makeCallingParams } = require('./calling-params');
 const checkContext = require('./check-context');
 const checkContextIf = require('./check-context-if');
 const client = require('./client');
@@ -26,7 +27,6 @@ const isProvider = require('./is-provider');
 const keep = require('./keep');
 const keepQuery = require('./keep-query');
 const lowerCase = require('./lower-case');
-const makeCallingParams = require('./make-calling-params');
 const mongoKeys = require('./mongo-keys');
 const paramsForServer = require('./params-for-server');
 const paramsFromClient = require('./params-from-client');
@@ -64,6 +64,8 @@ module.exports = Object.assign({ callbackToPromise,
   actOnDispatch,
   alterItems,
   cache,
+  callingParams,
+  callingParamsDefaults,
   checkContext,
   checkContextIf,
   client,

--- a/tests/services/calling-params-1.test.js
+++ b/tests/services/calling-params-1.test.js
@@ -1,0 +1,156 @@
+
+const { assert } = require('chai');
+const { callingParamsDefaults, callingParams } = require('../../lib');
+
+let context1, context2, context3, context4;
+
+describe('service calling-params-1.test.js', () => {
+  describe('has defaults', () => {
+    beforeEach(() => {
+      context1 = { params: { query: { aaa: 'bbb' }, foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true, provider: 'socketio' } };
+      context2 = { params: { query: { aaa: 'bbb' }, foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true } };
+      context3 = { params: { query: { aaa: 'bbb' }, foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true, provider: undefined } };
+      context4 = { params: { query: { aaa: 'bbb' }, foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true, provider: null } };
+    });
+
+    it('standard defaults', () => {
+      const res = callingParams()(context1);
+      assert.deepEqual(res, { user: { name: 'Matt' }, authenticated: true, provider: 'socketio' });
+    });
+
+    it('ignores missing', () => {
+      const res = callingParams()(context2);
+      assert.deepEqual(res, { user: { name: 'Matt' }, authenticated: true });
+    });
+
+    it('ignores undefined', () => {
+      const res = callingParams()(context3);
+      assert.deepEqual(res, { user: { name: 'Matt' }, authenticated: true });
+    });
+
+    it('does not ignore null', () => {
+      const res = callingParams()(context4);
+      assert.deepEqual(res, { user: { name: 'Matt' }, authenticated: true, provider: null });
+    });
+  });
+
+  describe('can reset defaults', () => {
+    beforeEach(() => {
+      context1 = { params: { query: { aaa: 'bbb' }, foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true, provider: 'socketio' } };
+
+      callingParamsDefaults(['provider', 'authenticated', 'user'], {});
+    });
+
+    it('check reset to standard defaults', () => {
+      const res = callingParams()(context1);
+      assert.deepEqual(res, { user: { name: 'Matt' }, authenticated: true, provider: 'socketio' });
+    });
+
+    it('change default propNames', () => {
+      callingParamsDefaults(['foo', 'user.name', 'query.aaa']);
+      const res = callingParams()(context1);
+      assert.deepEqual(res, { foo: 'bar', user: { name: 'Matt' }, query: { aaa: 'bbb' } });
+    });
+
+    it('change default props', () => {
+      callingParamsDefaults(null, { bar: 'foo' });
+      const res = callingParams()(context1);
+      assert.deepEqual(res, { user: { name: 'Matt' }, authenticated: true, provider: 'socketio', bar: 'foo' });
+    });
+
+    it('change both defaults', () => {
+      callingParamsDefaults(['foo', 'user.name', 'query.aaa'], { bar: 'foo', qqq: 'rrr' });
+      const res = callingParams()(context1);
+      assert.deepEqual(res, { foo: 'bar', user: { name: 'Matt' }, query: { aaa: 'bbb' }, bar: 'foo', qqq: 'rrr' });
+    });
+  });
+
+  describe('can call', () => {
+    beforeEach(() => {
+      context1 = { params: {
+        query: { aa: 'a1', bb: 'b1' }, foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true, provider: 'socketio' }
+      };
+
+      callingParamsDefaults(['provider', 'authenticated', 'user'], {});
+    });
+
+    it('default call made by common hooks', () => {
+      const res = callingParams()(context1);
+      assert.deepEqual(res, {
+        authenticated: true, provider: 'socketio', user: { name: 'Matt' }
+      });
+    });
+
+    it('with query', () => {
+      const res = callingParams({
+        query: { id: 1 }
+      })(context1);
+      assert.deepEqual(res, {
+        authenticated: true, provider: 'socketio', user: { name: 'Matt' }, query: { id: 1 }
+      });
+    });
+
+    it('with propNames', () => {
+      const res = callingParams({
+        propNames: ['foo', 'baz', 'query.aa', 'query.cc']
+      })(context1);
+      assert.deepEqual(res, {
+        authenticated: true, provider: 'socketio', user: { name: 'Matt' }, foo: 'bar', baz: 'faz', query: { aa: 'a1' }
+      });
+    });
+
+    it('disable 1 hook', () => {
+      const res = callingParams({
+        hooksToDisable: ['populate']
+      })(context1);
+      assert.deepEqual(res, {
+        authenticated: true, provider: 'socketio', user: { name: 'Matt' }, _populate: 'skip'
+      });
+    });
+
+    it('disable multiple hooks', () => {
+      const res = callingParams({
+        hooksToDisable: ['populate', 'fastJoin', 'softDelete', 'stashBefore']
+      })(context1);
+      assert.deepEqual(res, {
+        authenticated: true,
+        provider: 'socketio',
+        user: { name: 'Matt' },
+        _populate: 'skip',
+        query: { $disableSoftDelete: true, $disableStashBefore: true }
+      });
+    });
+
+    it('ignore defaults', () => {
+      let res = callingParams({
+        ignoreDefaults: true
+      })(context1);
+      assert.deepEqual(res, {});
+
+      res = callingParams({
+        propNames: ['foo', 'baz', 'query.aa', 'query.cc'],
+        ignoreDefaults: true
+      })(context1);
+      assert.deepEqual(res, {
+        foo: 'bar', baz: 'faz', query: { aa: 'a1' }
+      });
+    });
+
+    it('with multiple options', () => {
+      const res = callingParams({
+        query: { id: 1 },
+        propNames: ['foo', 'baz', 'query.aa', 'query.cc'],
+        hooksToDisable: ['populate', 'fastJoin', 'softDelete', 'stashBefore']
+      })(context1);
+      assert.deepEqual(res, {
+        query: { id: 1, aa: 'a1', $disableSoftDelete: true, $disableStashBefore: true },
+        foo: 'bar',
+        baz: 'faz',
+        _populate: 'skip',
+        user: { name: 'Matt' },
+        authenticated: true,
+        provider: 'socketio'
+      });
+    });
+  });
+});

--- a/tests/services/calling-params-2.test.js
+++ b/tests/services/calling-params-2.test.js
@@ -4,7 +4,7 @@ const { makeCallingParams } = require('../../lib');
 
 let context;
 
-describe('service make-calling-params.test.js', () => {
+describe('service calling-params-2.test.js', () => {
   beforeEach(() => {
     context = { query: { aaa: 'bbb' }, params: { foo: 'bar', baz: 'faz', user: { name: 'Matt' }, authenticated: true, provider: 'socketio' } };
   });

--- a/tests/services/exposed.js
+++ b/tests/services/exposed.js
@@ -7,6 +7,8 @@ const hookNames = [
   'actOnDispatch',
   'alterItems',
   'cache',
+  'callingParams',
+  'callingParamsDefaults',
   'callbackToPromise',
   'checkContext',
   'checkContextIf',


### PR DESCRIPTION
See docs for new hooks `callingParams` and `callingParamsdefault`.

`makeCallingParams`  is now a stub to `callingParams`. It is fully compatible with the previous 'makeCallingParams` hook.

`callingParams` should now be used instead of `makeCallingParams` as the former
- has more features
- common hooks will use it internally