### PR TITLE
Hook for signing in via "Basic" authentication in a "before" hook

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -210,7 +210,7 @@ export function getItems(context: HookContext): any; // any[] | any | undefined;
  * Check which transport provided the service call.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#IsProvider}
  */
-export function isProvider(...transports: TransportName[]): PredicateFn;
+export function isProvider(...transports: TransportName[]): boolean;
 
 /**
  * Keep certain fields in the record(s), deleting the rest.


### PR DESCRIPTION
# Summary

Hey Eddy, as discussed on [Slack](https://feathersjs.slack.com/archives/C0HJE6A65/p1530216141000160?thread_ts=1530126436.000082&cid=C0HJE6A65) here is the hook. 

I have the following questions:
- Is the way of actually signing in correct? (via the `/authentication` service?)
- I think we should make the props `username` and `password` flexible according to the `@feathers/configuration` JSON file. What do you think?
- Does this fit the codebase (ES5, ES6, ..?)

# Usage

```javascript
import { hooks } from '@feathersjs/authentication';
import { basicAuth } from './basic-auth';

// Combined call to basic auth hook and authenticate
const customAuth: any[] = [basicAuth(), hooks.authenticate('jwt')];

// For example to protect write actions:
export default {
    before: {
        all: [],
        find: [],
        get: [],
        create: [...customAuth],
        update: [...customAuth],
        patch: [...customAuth],
        remove: [...customAuth]
    },

    after: {
        all: [],
        find: [],
        get: [],
        create: [],
        update: [],
        patch: [],
        remove: []
    },

    error: {
        all: [],
        find: [],
        get: [],
        create: [],
        update: [],
        patch: [],
        remove: []
    }
};

```

I :heart: Feathers ;-)