### PR TITLE
[security issue] fix populate injecting provider into source schema argument

### DIFF
--- a/lib/services/populate.js
+++ b/lib/services/populate.js
@@ -59,8 +59,7 @@ module.exports = function (options, ...rest) {
             if ('provider' in schema) {
               return schema;
             } else {
-              schema.provider = provider;
-              return schema;
+              return Object.assign({}, schema, {provider});
             }
           });
 
@@ -235,8 +234,7 @@ function populateAddChild (options, context, parentItem, childSchema, depth) {
           if ('provider' in schema) {
             return schema;
           } else {
-            schema.provider = provider;
-            return schema;
+            return Object.assign({}, schema, {provider});
           }
         });
 

--- a/tests/services/populate-1deep-1child.test.js
+++ b/tests/services/populate-1deep-1child.test.js
@@ -538,6 +538,28 @@ let provider;
           });
       });
     });
+
+    describe('populate does not change original schema object', () => {
+      it('check include field', () => {
+        const hook = clone(hookAfterArray);
+        hook.app = app;
+
+        const includeOptions = () => ({
+          service: 'posts',
+          nameAs: 'post',
+          parentField: 'postId',
+          childField: 'id'
+        });
+
+        const include = makeInclude(type, includeOptions());
+        const expected = makeInclude(type, includeOptions());
+
+        return populate({ schema: {include}, profile: true })(hook)
+          .then(hook1 => {
+            assert.deepEqual(include, expected);
+          });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Summary

Populate hook is modifying original `options` argument in place causing provider field being injected into all subsequent populate calls. 

If the first populate call has been done with `provider = undefined` (for instance by restrictToOwner hook), populate inject this provider into original `options`. The second call from rest provider is performed with `provider = undefined` because that value was injected into `options` in previous popolate call. 

Such behavior is a severe security issue making possible to fetch related objects bypassing owner check.

More detailed description is given here:
[https://bitbucket.org/AntaraSI/feathers-populate-test](https://bitbucket.org/AntaraSI/feathers-populate-test)