### PR TITLE
Allows custom methods in checkContext

### DIFF
--- a/lib/services/check-context.js
+++ b/lib/services/check-context.js
@@ -1,10 +1,13 @@
 
+const stndMethods = ['find', 'get', 'create', 'update', 'patch', 'remove'];
+
 module.exports = function (context, type = null, methods = [], label = 'anonymous') {
   if (type && context.type !== type) {
     throw new Error(`The '${label}' hook can only be used as a '${type}' hook.`);
   }
 
   if (!methods) { return; }
+  if (stndMethods.indexOf(context.method) === -1) { return; } // allow custom methods
 
   const myMethods = Array.isArray(methods) ? methods : [methods]; // safe enough for allowed values
 

--- a/tests/services/check-context.test.js
+++ b/tests/services/check-context.test.js
@@ -76,4 +76,11 @@ describe('services checkContext', () => {
     assert.equal(checkContext(hook, 'before', ['create']), undefined);
     assert.equal(checkContext(hook, 'before', ['create', 'update', 'remove']), undefined);
   });
+
+  it('allows custom methods', () => {
+    hook.type = 'before';
+    hook.method = 'custom';
+    assert.equal(checkContext(hook, 'before', ['create']), undefined);
+    assert.equal(checkContext(hook, 'before', ['create', 'update', 'remove']), undefined);
+  });
 });


### PR DESCRIPTION
checkContext allows any methods other than find, get, create, update, patch, remove