### PR TITLE
Added `keepQuery` support for keeping props with dot in their name

### DIFF
--- a/lib/common/_pluck.js
+++ b/lib/common/_pluck.js
@@ -21,9 +21,9 @@ function _pluckItem (item, fieldNames) {
 
   fieldNames.forEach(fieldName => {
     const valueNotByDot = item[fieldName];
-    const value = valueNotByDot || getByDot(item, fieldName);
+    const value = typeof valueNotByDot !== 'undefined' ? valueNotByDot : getByDot(item, fieldName);
     if (value !== undefined) { // prevent setByDot creating nested empty objects
-      if (valueNotByDot) { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
+      if (typeof valueNotByDot !== 'undefined') { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
     }
   });
 

--- a/lib/common/_pluck.js
+++ b/lib/common/_pluck.js
@@ -20,10 +20,9 @@ function _pluckItem (item, fieldNames) {
   const plucked = {};
 
   fieldNames.forEach(fieldName => {
-    const valueNotByDot = item[fieldName];
-    const value = valueNotByDot !== undefined ? valueNotByDot : getByDot(item, fieldName);
+    const value = fieldName in item ? item[fieldName] : getByDot(item, fieldName);
     if (value !== undefined) { // prevent setByDot creating nested empty objects
-      if (valueNotByDot !== undefined) { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
+      if (fieldName in item) { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
     }
   });
 

--- a/lib/common/_pluck.js
+++ b/lib/common/_pluck.js
@@ -20,9 +20,10 @@ function _pluckItem (item, fieldNames) {
   const plucked = {};
 
   fieldNames.forEach(fieldName => {
-    const value = getByDot(item, fieldName);
+    const valueNotByDot = item[fieldName];
+    const value = valueNotByDot || getByDot(item, fieldName);
     if (value !== undefined) { // prevent setByDot creating nested empty objects
-      setByDot(plucked, fieldName, value);
+      if (valueNotByDot) { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
     }
   });
 

--- a/lib/common/_pluck.js
+++ b/lib/common/_pluck.js
@@ -21,9 +21,9 @@ function _pluckItem (item, fieldNames) {
 
   fieldNames.forEach(fieldName => {
     const valueNotByDot = item[fieldName];
-    const value = typeof valueNotByDot !== 'undefined' ? valueNotByDot : getByDot(item, fieldName);
+    const value = valueNotByDot !== undefined ? valueNotByDot : getByDot(item, fieldName);
     if (value !== undefined) { // prevent setByDot creating nested empty objects
-      if (typeof valueNotByDot !== 'undefined') { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
+      if (valueNotByDot !== undefined) { plucked[fieldName] = value; } else { setByDot(plucked, fieldName, value); }
     }
   });
 

--- a/tests/services/keep-query.test.js
+++ b/tests/services/keep-query.test.js
@@ -43,7 +43,7 @@ describe('services keepQuery', () => {
         type: 'before',
         method: 'create',
         params: {
-          query: { empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' }, dept: 'Acct' }
+          query: { empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' }, dept: 'Acct', 'owner.id': 1 }
         } };
     });
 
@@ -55,9 +55,9 @@ describe('services keepQuery', () => {
     });
 
     it('prop with 1 dot', () => {
-      hooks.keepQuery('empl.name', 'dept')(hookBefore);
+      hooks.keepQuery('empl.name', 'dept', 'owner.id')(hookBefore);
       assert.deepEqual(hookBefore.params.query,
-        { empl: { name: { first: 'John', last: 'Doe' } }, dept: 'Acct' }
+        { empl: { name: { first: 'John', last: 'Doe' } }, dept: 'Acct', 'owner.id': 1 }
       );
     });
 

--- a/tests/services/keep-query.test.js
+++ b/tests/services/keep-query.test.js
@@ -43,7 +43,7 @@ describe('services keepQuery', () => {
         type: 'before',
         method: 'create',
         params: {
-          query: { empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' }, dept: 'Acct', 'owner.id': 1 }
+          query: { empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' }, dept: 'Acct', 'owner.id': 1, 'owner.admin': false }
         } };
     });
 
@@ -55,9 +55,9 @@ describe('services keepQuery', () => {
     });
 
     it('prop with 1 dot', () => {
-      hooks.keepQuery('empl.name', 'dept', 'owner.id')(hookBefore);
+      hooks.keepQuery('empl.name', 'dept', 'owner.id', 'owner.admin')(hookBefore);
       assert.deepEqual(hookBefore.params.query,
-        { empl: { name: { first: 'John', last: 'Doe' } }, dept: 'Acct', 'owner.id': 1 }
+        { empl: { name: { first: 'John', last: 'Doe' } }, dept: 'Acct', 'owner.id': 1, 'owner.admin': false }
       );
     });
 


### PR DESCRIPTION
With ORM libraries (e.g. feathers-objection), the client sometimes need to query using a full field name (e.g. `'user.id=1'`) or filter by relation field (e.g. `'dept.name=Acct'`) and it will populate the query object in the server like this: `{ query: { 'user.id': 1 } }`

`keepQuery` hook currently only performs `getByDot` & `setByDot` using the `_pluck` module and these example queries will fail, since the `keepQuery` hook will always remove them.

I would like to be able to use `keepQuery('user.id', 'dept.name')` and would expect that the `_pluck` module will try simple `get & set` before resorting to the `getByDot & setByDot` hooks.