### PR TITLE
fix: isProvider returns a boolean

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -210,7 +210,7 @@ export function getItems(context: HookContext): any; // any[] | any | undefined;
  * Check which transport provided the service call.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#IsProvider}
  */
-export function isProvider(...transports: TransportName[]): SyncPredicateFn;
+export function isProvider(...transports: TransportName[]): SyncContextFunction<boolean>;
 
 /**
  * Keep certain fields in the record(s), deleting the rest.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -210,7 +210,7 @@ export function getItems(context: HookContext): any; // any[] | any | undefined;
  * Check which transport provided the service call.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#IsProvider}
  */
-export function isProvider(...transports: TransportName[]): PredicateFn;
+export function isProvider(...transports: TransportName[]): boolean;
 
 /**
  * Keep certain fields in the record(s), deleting the rest.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -210,7 +210,7 @@ export function getItems(context: HookContext): any; // any[] | any | undefined;
  * Check which transport provided the service call.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#IsProvider}
  */
-export function isProvider(...transports: TransportName[]): boolean;
+export function isProvider(...transports: TransportName[]): SyncPredicateFn;
 
 /**
  * Keep certain fields in the record(s), deleting the rest.

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -196,7 +196,7 @@ getByDot({}, 'abc.def');
 // $ExpectType any
 getItems(context1);
 
-// $ExpectType PredicateFn
+// $ExpectType SyncContextFunction<boolean>
 isProvider();
 
 // $ExpectType Hook


### PR DESCRIPTION
Hi Eddy,

as discussed on Slack, I think the `isProvider` method is returning a `boolean`.

The usage of it should therefore be changed in the docs as well I guess to something like:
```
iff(
        (context) => isProvider('external'), ...
```