### PR TITLE
Added `keepQueryInArray` hook to keep query fields from a nested array

### DIFF
--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -27,6 +27,7 @@ const isProvider = require('./is-provider');
 const keep = require('./keep');
 const keepInArray = require('./keep-in-array');
 const keepQuery = require('./keep-query');
+const keepQueryInArray = require('./keep-query-in-array');
 const lowerCase = require('./lower-case');
 const mongoKeys = require('./mongo-keys');
 const paramsForServer = require('./params-for-server');
@@ -91,6 +92,7 @@ module.exports = Object.assign({ callbackToPromise,
   keep,
   keepInArray,
   keepQuery,
+  keepQueryInArray,
   lowerCase,
   makeCallingParams,
   mongoKeys,

--- a/lib/services/keep-query-in-array.js
+++ b/lib/services/keep-query-in-array.js
@@ -1,0 +1,38 @@
+const checkContext = require('./check-context');
+const errors = require('@feathersjs/errors');
+const existsByDot = require('../common/exists-by-dot');
+const getByDot = require('../common/get-by-dot');
+const setByDot = require('../common/set-by-dot');
+
+module.exports = function (field, fieldNames) {
+  return context => {
+    checkContext(context, 'before', null, 'keepQueryInArray');
+
+    replaceIn(context.query, field, fieldNames);
+
+    return context;
+  };
+};
+
+function replaceIn (item, field, fieldNames) {
+  const target = getByDot(item, field);
+  if (target) {
+    if (!Array.isArray(target)) throw new errors.BadRequest(`The 'field' param must lead to array. found type '${typeof target}' instead`);
+
+    setByDot(item, field, target.map(item => replaceItem(item, fieldNames)));
+  }
+}
+
+function replaceItem (item, fields) {
+  if (typeof item !== 'object' || item === null) return item;
+
+  const newItem = {};
+  fields.forEach(field => {
+    if (!existsByDot(item, field)) return;
+
+    const value = getByDot(item, field);
+    setByDot(newItem, field, value);
+  });
+  item = newItem;
+  return item;
+}

--- a/tests/services/exposed.js
+++ b/tests/services/exposed.js
@@ -32,6 +32,7 @@ const hookNames = [
   'keep',
   'keepInArray',
   'keepQuery',
+  'keepQueryInArray',
   'lowerCase',
   'makeCallingParams',
   'mongoKeys',

--- a/tests/services/keep-query-in-array.test.js
+++ b/tests/services/keep-query-in-array.test.js
@@ -1,0 +1,160 @@
+const { assert } = require('chai');
+const hooks = require('../../lib/services');
+
+let hookBefore;
+let hookFindNested;
+
+describe('services keepQueryInArray', () => {
+  describe('removes fields', () => {
+    beforeEach(() => {
+      hookBefore = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: 'John', last: 'Doe' }] } };
+    });
+
+    it('updates hook before::find', () => {
+      hooks.keepQueryInArray('users', ['last'])(hookBefore);
+      assert.deepEqual(hookBefore.query, { users: [{ last: 'Doe' }] });
+    });
+
+    it('ignores bad or missing field', () => {
+      hooks.keepQueryInArray('xx', ['last'])(hookBefore);
+      assert.deepEqual(hookBefore.query, { users: [{ first: 'John', last: 'Doe' }] });
+    });
+
+    it('does not throw if field is missing', () => {
+      const hook = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: 'John', last: 'Doe' }] } };
+      hooks.keepQueryInArray('users', ['last', 'xx'])(hook);
+      assert.deepEqual(hook.query, { users: [{ last: 'Doe' }] });
+    });
+
+    it('keeps undefined values', () => {
+      const hook = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: undefined, last: 'Doe' }] } };
+      hooks.keepQueryInArray('users', ['first'])(hook);
+      assert.deepEqual(hook.query, { users: [{ first: undefined }] });
+    });
+
+    it('keeps null values', () => {
+      const hook = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: null, last: 'Doe' }] } };
+      hooks.keepQueryInArray('users', ['first'])(hook);
+      assert.deepEqual(hook.query, { users: [{ first: null }] });
+    });
+
+    it('keeps false values', () => {
+      const hook = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: false, last: 'Doe' }] } };
+      hooks.keepQueryInArray('users', ['first'])(hook);
+      assert.deepEqual(hook.query, { users: [{ first: false }] });
+    });
+
+    it('keeps 0 values', () => {
+      const hook = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: 0, last: 'Doe' }] } };
+      hooks.keepQueryInArray('users', ['first'])(hook);
+      assert.deepEqual(hook.query, { users: [{ first: 0 }] });
+    });
+
+    it('keeps empty string values', () => {
+      const hook = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ first: '', last: 'Doe' }] } };
+      hooks.keepQueryInArray('users', ['first'])(hook);
+      assert.deepEqual(hook.query, { users: [{ first: '' }] });
+    });
+  });
+
+  describe('handles dot notation', () => {
+    beforeEach(() => {
+      hookBefore = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' }, dept: 'Acct' }] }
+      };
+      hookFindNested = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { account: { users: [{ first: 'John', last: 'Doe' }] } }
+      };
+    });
+
+    it('updates hook find with dot notation field ', () => {
+      hooks.keepQueryInArray('account.users', ['first'])(hookFindNested);
+      assert.deepEqual(hookFindNested.query, { account: { users: [{ first: 'John' }] } });
+    });
+
+    it('prop with no dots', () => {
+      hooks.keepQueryInArray('users', ['empl'])(hookBefore);
+      assert.deepEqual(hookBefore.query,
+        { users: [{ empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' } }] }
+      );
+    });
+
+    it('prop with 1 dot', () => {
+      hooks.keepQueryInArray('users', ['empl.name', 'dept'])(hookBefore);
+      assert.deepEqual(hookBefore.query,
+        { users: [{ empl: { name: { first: 'John', last: 'Doe' } }, dept: 'Acct' }] }
+      );
+    });
+
+    it('prop with 2 dots', () => {
+      hooks.keepQueryInArray('users', ['empl.name.last', 'empl.status', 'dept'])(hookBefore);
+      assert.deepEqual(hookBefore.query,
+        { users: [{ empl: { name: { last: 'Doe' }, status: 'AA' }, dept: 'Acct' }] }
+      );
+    });
+
+    it('ignores bad or missing paths', () => {
+      hooks.keepQueryInArray('users', ['empl.name.first', 'empl.name.surname'])(hookBefore);
+      assert.deepEqual(hookBefore.query,
+        { users: [{ empl: { name: { first: 'John' } } }] }
+      );
+    });
+
+    it('ignores bad or missing no dot path', () => {
+      hooks.keepQueryInArray('users', ['xx'])(hookBefore);
+      assert.deepEqual(hookBefore.query, { users: [{}] });
+    });
+  });
+
+  describe('removes non-object records', () => {
+    beforeEach(() => {
+      hookBefore = {
+        type: 'before',
+        method: 'find',
+        params: { provider: 'rest' },
+        query: { users: [{ empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' }, dept: 'Acct' }, null, undefined, Infinity] }
+      };
+    });
+
+    it('before', () => {
+      hooks.keepQueryInArray('users', ['empl'])(hookBefore);
+      assert.deepEqual(hookBefore.query,
+        { users: [{ empl: { name: { first: 'John', last: 'Doe' }, status: 'AA' } }, null, undefined, Infinity] }
+      );
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -235,6 +235,12 @@ export function keepInArray(arrayName: string, fieldNames: string[]): Hook;
 export function keepQuery(...fieldNames: string[]): Hook;
 
 /**
+ * Keep certain fields in a nested array inside the query object, deleting the rest.
+ * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#KeepQueryInArray}
+ */
+export function keepQueryInArray(arrayName: string, fieldNames: string[]): Hook;
+
+/**
  * Convert certain field values to lower case.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#LowerCase}
  */

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -32,6 +32,7 @@ import {
     keep,
     keepInArray,
     keepQuery,
+    keepQueryInArray,
     lowerCase,
     makeCallingParams,
     mongoKeys,
@@ -222,6 +223,9 @@ keepInArray('array', ['fieldName', 'fieldName']);
 
 // $ExpectType Hook
 keepQuery('name', 'address.city');
+
+// $ExpectType Hook
+keepQueryInArray('array', ['fieldName', 'fieldName']);
 
 // $ExpectType Hook
 lowerCase('email', 'username', 'div.dept');


### PR DESCRIPTION
### Problem
The `keepQuery` hook does a great job for its intended purpose, but it won't work for nested arrays. for example, querying records with the `$or` operator, when `keepQuery('$or', ...)` is defined, can bypass any `keepQuery` restriction.

### Solution
This new `keepQueryInArray` hook works like `keepQuery`, but it accepts 2 arguments. the first is a dot notation string type field and the second is an array of field names to keep from it.

### Usage

Query data structures:
```js
{ 
  users: [
    {
      name: 'John',
      secret: 'doNotKeep',
      dept: 'Accounting',
      address: {
        city: 'New York',
        secret: 'doNotKeep'
      }
    }
  ],
  owner: 'Jane Doe'
}

{
  account: {
    users: [
      {
        name: 'John',
        secret: 'doNotKeep',
        dept: 'Accounting',
        address: {
          city: 'New York',
          secret: 'doNotKeep'
        }
      }
    ],
    owner: 'Jane Doe'
  }
}
```

Using hook:
``` js
const { keepQueryInArray } = require('feathers-hooks-common');
    
module.exports = { after: {
  create: keepQueryInArray('users', ['name', 'dept', 'address.city']),
  find: keepQueryInArray('account.users', ['name', 'dept', 'address.city']),
} };
```

Query data structures after using hook:
```js
{ 
  users: [
    {
      name: 'John',
      dept: 'Accounting',
      address: {
        city: 'New York'
      }
    }
  ],
  owner: 'Jane Doe'
}

{
  account: {
    users: [
      {
        name: 'John',
        dept: 'Accounting',
        address: {
          city: 'New York'
        }
      }
    ],
    owner: 'Jane Doe'
  }
}
```

Added tests and [PR](https://github.com/feathers-plus/docs/pull/52) to the feathers-plus docs.