### PR TITLE
Allow $populate: object, don’t skip the hook

### DIFF
--- a/lib/services/fgraphql.js
+++ b/lib/services/fgraphql.js
@@ -48,9 +48,10 @@ module.exports = function fgraphql (options1 = {}) {
     const contextParams = context.params;
     const optSkipHookWhen = options.skipHookWhen;
     const skipHookWhen = isFunction(optSkipHookWhen) ? optSkipHookWhen(context) : optSkipHookWhen;
+    const $populate = context.params.$populate;
     debug(`\n.....hook called. type ${context.type} method ${context.method} resolved skipHookWhen ${skipHookWhen}`);
 
-    if (context.params.$populate) return context; // populate or fastJoin are running
+    if ($populate && (Array.isArray($populate) || typeof $populate === 'string')) return context; // populate or fastJoin are running
     if (skipHookWhen) return context;
 
     const query = isFunction(query1) ? query1(context) : query1;


### PR DESCRIPTION
Changes behavior of the fgraphql hook with regards to `context.params.$populate`.  Instead of skipping requests where `$populate` exists, this skips requests where `$populate` is either an array or a string, thus allowing `$populate: { }`

```js
$populate = {
  email: 1,
  posts: {}
}
```