### PR TITLE
remove dtslint workaround in favor of npx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ node_modules
 
 dist/
 .idea/
-dtslint-build/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:major": "npm version major && npm publish",
     "changelog": "github_changelog_generator && git add CHANGELOG.md && git commit -am \"Updating changelog\"",
     "lint": "semistandard --fix",
-    "lint:types": "mkdirp dtslint-build && cd dtslint-build && echo '{\"devDependencies\":{\"dtslint\":\"^0.3.0\"},\"scripts\":{\"dtslint\":\"dtslint ../types\"}}' > package.json && npm install && npm run dtslint",
+    "lint:types": "npx dtslint types",
     "mocha": "mocha --opts mocha.opts",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run lint && npm run lint:types && npm run coverage"


### PR DESCRIPTION
work in progress.

fixes #461, but requires npx (npm@^5.2.0) to be present, so it ~could~ will break type linting for people without npx installed.

The solution was taken from https://github.com/ReactiveX/rxjs/pull/4088 as it was the only workaround I could find and I trust the rxjs guys' expertise. If someone can come up with a better workaround please step forward.