### PR TITLE
Add initial types for fgraphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@feathersjs/socketio": "^3.2.2",
     "@feathersjs/socketio-client": "^1.1.0",
     "@types/feathersjs__feathers": "^3.0.4",
+    "@types/graphql": "^14.0.3",
     "chai": "^4.1.2",
     "clone": "^2.1.1",
     "coveralls": "^3.0.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,7 @@
 
 import { Hook, HookContext, Params, Query, Paginated } from '@feathersjs/feathers';
 import * as ajv from 'ajv';
+import { GraphQLSchema } from 'graphql';
 
 export type HookType = 'before' | 'after' | 'error';
 export type MethodName = 'find' | 'create' | 'get' | 'update' | 'patch' | 'remove';
@@ -197,6 +198,42 @@ export interface ResolverMap<T> {
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#FastJoin}
  */
 export function fastJoin(resolvers: ResolverMap<any> | SyncContextFunction<ResolverMap<any>>, query?: Query | SyncContextFunction<Query>): Hook;
+
+interface IFGraphqlOptions {
+    parse: (schema: any /* GraphqlSchema */) => any;
+    recordType: string;
+    resolvers: (app: any /* App */, runtime: any) => ResolverMap<any>;
+    schema: GraphQLSchema;
+    query: any /* Query? */;
+    runTime: any;
+    skipHookWhen?: Hook,
+    /**
+     * @default true
+     */
+    inclAllFieldsServer?: boolean,
+    /**
+     * @default true
+     */
+    inclAllFieldsClient?: boolean,
+
+    /**
+     * @default null
+     */
+    inclAllFields?: Hook,
+    /**
+     * @default true
+     */
+    inclJoinedNames?: boolean,
+    /**
+     * @default []
+     */
+    extraAuthProps?: string[]
+}
+
+/**
+ * fgraphql hook
+ */
+export function fgraphql(options: IFGraphqlOptions): Hook;
 
 /**
  * Return a property value from an object using dot notation, e.g. address.city. (Utility function.)


### PR DESCRIPTION
### Summary
Add initial version of types for fgraphql. This was erroring (for some reason, not quite sure why though) in my project, which was generated by feathers+ cli. So I thought I'd get these started.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
#467 
- [ ] Is this PR dependent on PRs in other repos?

### Other Information
There are a few enhancements that we could do still, to query, runtime, parse function return and possibly resolvers (a generic type for ResolverMap)

Docs issue #466 


question: Why is there an async version and a non-async version. As far as I can tell they are actually the same implementation, with different keywords