### PR TITLE
required() of value false throws fieldname is null

### DIFF
--- a/lib/services/required.js
+++ b/lib/services/required.js
@@ -14,7 +14,7 @@ module.exports = function (...fieldNames) {
       fieldNames.forEach(name => {
         if (!existsByDot(item, name)) throw new errors.BadRequest(`Field ${name} does not exist. (required)`);
         const value = getByDot(item, name);
-        if (!value && value !== 0) throw new errors.BadRequest(`Field ${name} is null. (required)`);
+        if (!value && value !== 0 && value !== false) throw new errors.BadRequest(`Field ${name} is null. (required)`);
       });
     });
   };


### PR DESCRIPTION
When trying to require boolean fields, value `false` should not thow an error.
Haven't found any related issues.
It's independent PR.