### PR TITLE
Remove redundant $eq to be compatible with all database adapters

### DIFF
--- a/lib/services/soft-delete-2.js
+++ b/lib/services/soft-delete-2.js
@@ -3,7 +3,7 @@
  How the softDelete2 hook is to be positioned relative to other possible hooks:
 
  before: {
-   // Add { deletedAt: { $eq: -1 } } to params.query.
+   // Add { deletedAt: -1 } to params.query.
    find:   [...hooks1, softDelete(), ...hooks2],
    // Add { deletedAt: -1 } to the (array of) data objects.
    // Existing deletedAt props will not be overridden if options.keepOnCreate = true.
@@ -19,10 +19,10 @@
    // before: softDelete2() is a no-op. after: softDelete2() throws if record is marked deleted.
    get:    [...hooks1, softDelete({ skipProbeOnGet: true }), ...hooks2], // options.skipProbeOnGet: true
    // If context.id provided: throw if record is deleted, else continue.
-   // If not provided: add { deletedAt: { $eq: -1 } } to params.query.
+   // If not provided: add { deletedAt: -1 } to params.query.
    patch:  [...hooks1, softDelete(), ...hooks2],
    // If context.id provided: throw if record is deleted.
-   // If not provided: add { deletedAt: { $eq: -1 } } to params.query.
+   // If not provided: add { deletedAt: -1 } to params.query.
    // Then in both cases: perform a removing patch call. On this removing patch call
    // - before hooks positioned before softDelete will be run.
    // - before hooks positioned after softDelete will not be run.
@@ -110,7 +110,7 @@ module.exports = function (options = {}) {
 
     switch (method) {
       case 'find':
-        context.params.query = addField(context.params.query, deletedAt, { $eq: -1 });
+        context.params.query = addField(context.params.query, deletedAt, -1);
         return context;
       case 'create':
         const data = context.data;
@@ -134,13 +134,13 @@ module.exports = function (options = {}) {
           return context;
         }
 
-        context.params.query = addField(context.params.query, deletedAt, { $eq: -1 });
+        context.params.query = addField(context.params.query, deletedAt, -1);
         return context;
       case 'remove':
         if (hasId) {
           await getActiveRecord(options, context);
         } else {
-          context.params.query = addField(context.params.query, deletedAt, { $eq: -1 });
+          context.params.query = addField(context.params.query, deletedAt, -1);
         }
 
         context.result = await patchCall(context, options);


### PR DESCRIPTION
This is part of making softDelete2 compatible with all database adapters.

Addresses (at least partially): https://github.com/feathers-plus/feathers-hooks-common/issues/455.

Further work is needed for full compatiblity as outlined in https://github.com/feathers-plus/feathers-hooks-common/blob/master/lib/README.md, but will be done in separate PR.