### PR TITLE
Fix promise-to-callback hook preventing other hook import.

### DIFF
--- a/lib/services/promise-to-callback.js
+++ b/lib/services/promise-to-callback.js
@@ -1,11 +1,11 @@
 
 /* globals setImmediate:1 */
 
-const asap = process && typeof process.nextTick === 'function'
-  ? process.nextTick : setImmediate;
-
 module.exports = function (promise) {
   console.log('**Deprecated** The promiseToCallback hook will be removed next FeathersJS version.');
+
+  const asap = process && typeof process.nextTick === 'function'
+    ? process.nextTick : setImmediate;
 
   return cb => {
     promise.then(


### PR DESCRIPTION
### Summary

Current version of promise-to-callback hook breaks importing in TypeScript. For projects that run in environment where neighter `process` nor `setImmediate` exist, you cant do:
`import { paramsForServer } from 'feathers-hooks-common';`
(in my case, angular 6 application)

Code compiles but `setImmediate is not defined` error is thrown. Even without using this particular hook.