### PR TITLE
Update iff predicates typings to be either sync or async

### DIFF
--- a/tests/services/iffelse.test.js
+++ b/tests/services/iffelse.test.js
@@ -65,6 +65,28 @@ describe('services iffElse', () => {
     hookFcnAsyncCalls = 0;
   });
 
+  describe('runs single hook', () => {
+    it('when true', () => {
+      return hooks.iffElse(true, hookFcnSync, hookFcnAsync)(hook)
+        .then(hook => {
+          assert.deepEqual(hook, hookAfter);
+          assert.equal(hookFcnSyncCalls, 1);
+          assert.equal(hookFcnAsyncCalls, 0);
+          assert.deepEqual(hook, hookAfter);
+        });
+    });
+
+    it('when false', () => {
+      return hooks.iffElse(false, hookFcnSync, hookFcnAsync)(hook)
+        .then(hook => {
+          assert.deepEqual(hook, hookAfter);
+          assert.equal(hookFcnSyncCalls, 0);
+          assert.equal(hookFcnAsyncCalls, 1);
+          assert.deepEqual(hook, hookAfter);
+        });
+    });
+  });
+
   describe('runs multiple hooks', () => {
     it('when true', () => {
       return hooks.iffElse(true, [hookFcnSync, hookFcnAsync, hookFcnCb], null)(hook)
@@ -154,6 +176,6 @@ describe('services iffElse', () => {
 
 // Helpers
 
-function clone (obj) {
+function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -547,7 +547,7 @@ export function validateSchema(schema: object, ajv: AjvOrNewable, options?: Vali
  * Execute one array of hooks or another based on a sync or async predicate.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#IffElse}
  */
-export function iffElse(predicate: SyncPredicateFn, hooksTrue: Hook | Hook[], hooksFalse: Hook | Hook[]): Hook;
+export function iffElse(predicate: PredicateFn, hooksTrue: Hook | Hook[], hooksFalse: Hook | Hook[]): Hook;
 
 export interface IffHook extends Hook {
     else(...hooks: Hook[]): Hook;
@@ -557,7 +557,7 @@ export interface IffHook extends Hook {
  * Execute one or another series of hooks depending on a sync or async predicate.
  * {@link https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#Iff}
  */
-export function iff(predicate: SyncPredicateFn, ...hooks: Hook[]): IffHook;
+export function iff(predicate: PredicateFn, ...hooks: Hook[]): IffHook;
 
 /**
  * Alias for iff

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -260,7 +260,7 @@ const fgraphqlOptions2: FGraphQLHookOptions = {
         Query: {}
     },
     options: {
-        extraAuthProps:  ['asdf' ],
+        extraAuthProps: ['asdf'],
         inclAllFields: false,
         inclJoinedNames: false,
         inclAllFieldsClient: true,
@@ -306,7 +306,7 @@ makeCallingParams(
 // tslint:disable-next-line
 class ObjId {
     // tslint:disable-next-line
-    constructor(id?: string | number) {}
+    constructor(id?: string | number) { }
 }
 
 // $ExpectType Hook
@@ -388,17 +388,17 @@ setNow('createdAt', 'updatedAt');
 setSlug('storeId');
 
 // $ExpectType Hook
-sequelizeConvert ({
+sequelizeConvert({
     aBool: 'boolean',
     aDate: 'date',
     anObject: 'json',
     aNumber: 'strToInt'
 }, null, {
-    strToInt: {
-        js: (sqlValue: string) => +sqlValue,
-        sql: (jsValue: number) => `${jsValue}`,
-    }
-});
+        strToInt: {
+            js: (sqlValue: string) => +sqlValue,
+            sql: (jsValue: number) => `${jsValue}`,
+        }
+    });
 
 // $ExpectType Hook
 sifter(ctx => item => true);
@@ -449,11 +449,17 @@ validateSchema({}, ajv);
 
 // $ExpectType Hook
 iffElse(syncTrue, [hook1, hook2], [hook3, hook4]);
+// $ExpectType Hook
+iffElse(asyncTrue, [hook1, hook2], [hook3, hook4]);
 
 // $ExpectType IffHook
 iff(syncTrue, hook1, hook2);
+// $ExpectType IffHook
+iff(asyncTrue, hook1, hook2);
 // $ExpectType Hook
 iff(syncTrue, hook1, hook2).else(hook3, hook4);
+// $ExpectType Hook
+iff(asyncTrue, hook1, hook2).else(hook3, hook4);
 
 // $ExpectType IffHook
 when(syncTrue, hook1, hook2);


### PR DESCRIPTION
### Summary
- [x] Tell us about the problem your pull request is solving.
The iff* hooks were typed to only accept synchronous predicate functions
This PR adds
1. Typescript type definitions for Asynchronous (in addition to the previous synchronous), Predicate functions
2. Typescript type tests (in types/tests.ts) to test for Async Predicates
3. 2 more tests for Iffelse to get it to 100% code coverage in normal (non-typescript) tests
- [x] Are there any open issues that are related to this?
No
- [x] Is this PR dependent on PRs in other repos?
no

If so, please mention them to keep the conversations linked together.

### Other Information

There are a few small updates to docs to happen, there are more after my next PR

#### iffElse
arguments - `{Function} predicate` -> `{Boolean | Promise | Function} predicate`

#### iffElse
arguments - `{Function | Boolean} predicate` -> `{Boolean | Promise | Function} predicate`